### PR TITLE
Don't create an SSH key for the app pod when the pod is just updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.12"
+  - "1.13"
 env:
   - GO111MODULE=on
 before_install:


### PR DESCRIPTION
because sometime we get the update event and we try to create the key
again. Since the key already exists, we fail and thus the update fails
too.

Fixes https://github.com/cloudfoundry-incubator/kubecf/issues/1016